### PR TITLE
Add HOL Registry Broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ API | Description | Auth | HTTPS | Free
 | [OpenAI](https://platform.openai.com/) | Text, image, and chat AI models | `apiKey` | ✅ | Paid |
 | [Replicate](https://replicate.com/) | Cloud-based ML model execution | `apiKey` | ✅ | Paid |
 | [Hugging Face Inference API](https://huggingface.co/inference-api) | Run transformers & LLMs in the cloud | `apiKey` | ✅ | Freemium |
+| [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Discover AI agents & MCP servers (OpenAPI available) | `apiKey` | ✅ | Free |
 
 ---
 


### PR DESCRIPTION
Adds Hashgraph Online (HOL) Registry Broker / Universal Agentic Registry API to the AI & Machine Learning section.\n\nDocs: https://hol.org/docs/registry-broker/\nOpenAPI: https://hol.org/registry/api/v1/openapi.json\nBase: https://hol.org/registry/api/v1\nAPIs.json: https://hol.org/registry/apis.json