### PR TITLE
Add Sharpe to finance APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ API | Description | Auth | HTTPS | Free
 | [Alpha Vantage](https://www.alphavantage.co/) | Stock and forex market data | `apiKey` | ✅ | Free |
 | [Finnhub](https://finnhub.io/) | Real-time financial data | `apiKey` | ✅ | Freemium |
 | [Yahoo Finance](https://finance.yahoo.com/) | Global financial market data | None | ✅ | Free |
+| [Sharpe](https://www.sharpe.ai/docs/free-api) | Crypto market intelligence for derivatives, funding rates, arbitrage, narratives, listings, and news | No | ✅ | Free |
 
 ---
 


### PR DESCRIPTION
Adds Sharpe to the Finance API table.

The entry links to Sharpe's free API documentation and follows the existing table columns. I used `No` for Auth because the linked public endpoints work without a required API key; API keys are optional for higher limits.

Website URL: https://www.sharpe.ai/docs/free-api
Validation: `git diff --check` passes.
Linear: SHA-188

Disclosure: I work on Sharpe.