### PR TITLE
Add Latchshot to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ API | Description | Auth | HTTPS | Free
 | [RapidAPI](https://rapidapi.com/) | API marketplace & hub | `apiKey` | ✅ | Free |
 | [Postman Public APIs](https://www.postman.com/explore) | Shared API collections for developers | None | ✅ | Free |
 | [ReqRes](https://reqres.in/) | Mock API for testing frontend apps | None | ✅ | Free |
+| [Latchshot](https://latchshot.fly.dev/docs.md) | Guarded screenshot and PDF rendering for public webpages | `apiKey` | ✅ | Freemium |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Latchshot to Developer Tools as a freemium screenshot and PDF rendering API for public webpages.

## Verification

- Documentation: https://latchshot.fly.dev/docs.md
- OpenAPI 3.1: https://latchshot.fly.dev/openapi.json
- Health: https://latchshot.fly.dev/healthz
- Authentication: Bearer API key
- Free tier: 100 successful renders per UTC calendar month

Disclosure: I maintain Latchshot. This is a direct-provider submission; the entry makes no adoption or endorsement claim.