### PR TITLE
Add DepthFeed to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ API | Description | Auth | HTTPS | Free
 |:---|:---|:---|:---|:---|
 | [Mboum Finance](https://mboum.com/api) | Stock, options, and market fundamentals | `apiKey` | ✅ | Freemium |
 | [Alpha Vantage](https://www.alphavantage.co/) | Stock and forex market data | `apiKey` | ✅ | Free |
+| [DepthFeed](https://depthfeed.com/docs) | Historical prediction-market order-book depth for backtesting | `apiKey` | ✅ | Freemium |
 | [Finnhub](https://finnhub.io/) | Real-time financial data | `apiKey` | ✅ | Freemium |
 | [Yahoo Finance](https://finance.yahoo.com/) | Global financial market data | None | ✅ | Free |
 


### PR DESCRIPTION
## Summary

Adds DepthFeed to Finance.

DepthFeed is a documented, self-serve REST API for historical and live prediction-market order-book data. It uses API-key authentication, HTTPS, and offers a permanent free Explorer plan without requiring a payment method.

The documentation and health endpoint return HTTP 200. I searched the README and open/closed pull requests for duplicates, kept the existing table format, and ran `git diff --check`.

Affiliation disclosure: I am submitting this on behalf of the DepthFeed team.
