### PR TITLE
Add Live Tennis API to Sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ API | Description | Auth | HTTPS | Free
 | [TheSportsDB](https://www.thesportsdb.com/) | Community-driven sports database | `apiKey` | ✅ | Free |
 | [SportsData.io](https://sportsdata.io/) | Major sports stats and odds | `apiKey` | ✅ | Paid |
 | [World Cup 2026 Tour](https://ay-worldcup2026.zeabur.app/developers) | World Cup 2026 fixtures, local-time conversion, and calendar links | No | ✅ | Free |
+| [Live Tennis API](https://livetennisapi.com/) | Tennis live scores, rankings, and fixtures — free keyed tier | `apiKey` | ✅ | Freemium |
 
 ---
 


### PR DESCRIPTION
Adds one row to the Sports section: **Live Tennis API** — tennis live scores (with serving and break-point state), player rankings, and fixtures. Free keyed tier (30 req/min, 100 req/day); paid tiers add match history, point-by-point, and more. Auth `apiKey`, HTTPS, CORS enabled. Docs: https://docs.livetennisapi.com

Row matches the existing column format (API | Description | Auth | HTTPS | Free).

Disclosure: I run this API.
