### PR TITLE
Add TempMailGrab to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ API | Description | Auth | HTTPS | Free
 | [RapidAPI](https://rapidapi.com/) | API marketplace & hub | `apiKey` | ✅ | Free |
 | [Postman Public APIs](https://www.postman.com/explore) | Shared API collections for developers | None | ✅ | Free |
 | [ReqRes](https://reqres.in/) | Mock API for testing frontend apps | None | ✅ | Free |
+| [TempMailGrab](https://tempmailgrab.com/api-docs) | Disposable inboxes with OTP extraction for QA tests | `apiKey` | ✅ | Freemium |
 
 ---
 


### PR DESCRIPTION
Adds TempMailGrab as a freemium disposable email API for QA and OTP testing.