### PR TITLE
Add 0xArchive to Finance APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ API | Description | Auth | HTTPS | Free
 | [Mboum Finance](https://mboum.com/api) | Stock, options, and market fundamentals | `apiKey` | ✅ | Freemium |
 | [Alpha Vantage](https://www.alphavantage.co/) | Stock and forex market data | `apiKey` | ✅ | Free |
 | [Finnhub](https://finnhub.io/) | Real-time financial data | `apiKey` | ✅ | Freemium |
+| [0xArchive](https://docs.0xarchive.io/) | Market data for Hyperliquid and Lighter | `apiKey` | ✅ | Freemium |
 | [Yahoo Finance](https://finance.yahoo.com/) | Global financial market data | None | ✅ | Free |
 
 ---


### PR DESCRIPTION
Adds 0xArchive to the Finance section.

0xArchive provides real-time and historical market data for Hyperliquid and Lighter via API access.

* **Auth:** API key
* **HTTPS:** Yes
* **Free tier:** Freemium

Docs: https://docs.0xarchive.io/
